### PR TITLE
Add support for subscribing to client state changes.

### DIFF
--- a/browser/webext/netcode.js
+++ b/browser/webext/netcode.js
@@ -7,6 +7,7 @@ var _typeGetClientState = 106;
 var _typeDestroyClient = 107;
 var _typeClientDestroyed = 108;
 var _typeCheckPresence = 109;
+var _typeClientStateChanged = 110;
 var _resultClientCreated = 201;
 var _resultSuccess = 202;
 var _resultError = 203;
@@ -146,6 +147,7 @@ window.netcode = {
         var clientId = args[0];
         _clients[clientId] = {
           _recvCallbacks: [],
+		  _stateChangeCallbacks: [],
           _isDestroyed: false,
           setTickRate: function(tickRate, callback) {
             if (this._isDestroyed) {
@@ -182,6 +184,9 @@ window.netcode = {
             if (type == "receive") {
               this._recvCallbacks.push(callback);
             }
+			else if(type == "stateChange") {
+			  this._stateChangeCallbacks.push(callback);
+			}
           },
         };
         callback(null, _clients[clientId]);
@@ -216,6 +221,15 @@ window.addEventListener("message", function(event) {
       _clients[clientId]._isDestroyed = true;
       delete _clients[clientId];
       // TODO: Fire event before deletion.
+	} else if (resultType == _typeClientStateChanged) {
+      // Client state changed
+	  var clientId = event.data.message[1];
+	  var stateStr = event.data.message[2];
+	  if(_clients[clientId] != undefined) {
+		for (var i = 0; i < _clients[clientId]._stateChangeCallbacks.length; i++) {
+          _clients[clientId]._stateChangeCallbacks[i](clientId, stateStr);
+        }
+	  }
     } else {
       // Received a return value.
       var messageId = event.data.message[1];

--- a/browser/webext/netcode.js
+++ b/browser/webext/netcode.js
@@ -147,7 +147,7 @@ window.netcode = {
         var clientId = args[0];
         _clients[clientId] = {
           _recvCallbacks: [],
-		  _stateChangeCallbacks: [],
+          _stateChangeCallbacks: [],
           _isDestroyed: false,
           setTickRate: function(tickRate, callback) {
             if (this._isDestroyed) {
@@ -184,9 +184,9 @@ window.netcode = {
             if (type == "receive") {
               this._recvCallbacks.push(callback);
             }
-			else if(type == "stateChange") {
-			  this._stateChangeCallbacks.push(callback);
-			}
+            else if(type == "stateChange") {
+              this._stateChangeCallbacks.push(callback);
+            }
           },
         };
         callback(null, _clients[clientId]);
@@ -221,15 +221,15 @@ window.addEventListener("message", function(event) {
       _clients[clientId]._isDestroyed = true;
       delete _clients[clientId];
       // TODO: Fire event before deletion.
-	} else if (resultType == _typeClientStateChanged) {
+    } else if (resultType == _typeClientStateChanged) {
       // Client state changed
-	  var clientId = event.data.message[1];
-	  var stateStr = event.data.message[2];
-	  if(_clients[clientId] != undefined) {
-		for (var i = 0; i < _clients[clientId]._stateChangeCallbacks.length; i++) {
+      var clientId = event.data.message[1];
+      var stateStr = event.data.message[2];
+      if(_clients[clientId] != undefined) {
+        for (var i = 0; i < _clients[clientId]._stateChangeCallbacks.length; i++) {
           _clients[clientId]._stateChangeCallbacks[i](clientId, stateStr);
         }
-	  }
+      }
     } else {
       // Received a return value.
       var messageId = event.data.message[1];

--- a/netcode.io.demoserver/Program.cs
+++ b/netcode.io.demoserver/Program.cs
@@ -82,7 +82,7 @@ namespace netcode.io.demoserver
             // Run netcode.io server in another thread.
             var netcodeThread = new Thread(NetcodeServer);
             netcodeThread.IsBackground = !nonInteractive;
-            netcodeThread.Start();
+			netcodeThread.Start();
 
             Console.WriteLine("netcode.io demo server started, open up http://" + httpAddress + ":" + httpPort + "/ to try it!");
             if (!nonInteractive)

--- a/netcode.io.demoserver/Program.cs
+++ b/netcode.io.demoserver/Program.cs
@@ -82,7 +82,7 @@ namespace netcode.io.demoserver
             // Run netcode.io server in another thread.
             var netcodeThread = new Thread(NetcodeServer);
             netcodeThread.IsBackground = !nonInteractive;
-			netcodeThread.Start();
+            netcodeThread.Start();
 
             Console.WriteLine("netcode.io demo server started, open up http://" + httpAddress + ":" + httpPort + "/ to try it!");
             if (!nonInteractive)

--- a/netcode.io.host/Program.cs
+++ b/netcode.io.host/Program.cs
@@ -42,7 +42,7 @@ namespace netcode.io.host
         const int TypeDestroyClient = 107;
         const int TypeClientDestroyed = 108;
         const int TypeCheckPresence = 109;
-		const int TypeClientStateChanged = 110;
+        const int TypeClientStateChanged = 110;
 
         const int ResultClientCreated = 201;
         const int ResultSuccess = 202;
@@ -259,18 +259,18 @@ namespace netcode.io.host
             var id = (int)o;
             var managedClient = _clients[id];
 
-			// keep track of client state so we can notify application of state changes
-			var prevState = managedClient.client.State;
+            // keep track of client state so we can notify application of state changes
+            var prevState = managedClient.client.State;
 			
             while (managedClient.shouldRun)
             {
                 managedClient.client.Update(managedClient.time);
 				
-				if (managedClient.client.State != prevState)
-				{
-					prevState = managedClient.client.State;
-					PostStateChange(id);
-				}
+                if (managedClient.client.State != prevState)
+                {
+                    prevState = managedClient.client.State;
+                    PostStateChange(id);
+                }
 
                 if (managedClient.client.State == ClientState.Connected)
                 {
@@ -313,52 +313,74 @@ namespace netcode.io.host
             managedClient.client.Dispose();
         }
 
-		private static void PostStateChange( int id )
-		{
-			string state;
-			switch (_clients[id].client.State)
-			{
-				case ClientState.Connected:
-					state = "connected";
-					break;
-				case ClientState.ConnectionDenied:
-					state = "connectionDenied";
-					break;
-				case ClientState.ConnectionRequestTimeout:
-					state = "connectionRequestTimeout";
-					break;
-				case ClientState.ConnectionResponseTimeout:
-					state = "connectionResponseTimeout";
-					break;
-				case ClientState.ConnectionTimedOut:
-					state = "connectionTimedOut";
-					break;
-				case ClientState.ConnectTokenExpired:
-					state = "connectTokenExpired";
-					break;
-				case ClientState.Disconnected:
-					state = "disconnected";
-					break;
-				case ClientState.InvalidConnectToken:
-					state = "invalidConnectToken";
-					break;
-				case ClientState.SendingConnectionRequest:
-					state = "sendingConnectionRequest";
-					break;
-				case ClientState.SendingConnectionResponse:
-					state = "sendingConnectionResponse";
-					break;
-				default:
-					state = "unknown";
-					break;
-			}
+        private static void PostStateChange( int id )
+        {
+            string state;
+            switch (_clients[id].client.State)
+            {
+                case ClientState.Connected:
+                    {
+                        state = "connected";
+                        break;
+                    }
+                case ClientState.ConnectionDenied:
+                    {
+                        state = "connectionDenied";
+                        break;
+                    }
+                case ClientState.ConnectionRequestTimeout:
+                    {
+                        state = "connectionRequestTimeout";
+                        break;
+                    }
+                case ClientState.ConnectionResponseTimeout:
+                    {
+                        state = "connectionResponseTimeout";
+                        break;
+                    }
+                case ClientState.ConnectionTimedOut:
+                    {
+                        state = "connectionTimedOut";
+                        break;
+                    }
+                case ClientState.ConnectTokenExpired:
+                    {
+                        state = "connectTokenExpired";
+                        break;
+                    }
+                case ClientState.Disconnected:
+                    {
+                        state = "disconnected";
+                        break;
+                    }
+                case ClientState.InvalidConnectToken:
+                    {
+                        state = "invalidConnectToken";
+                        break;
+                    }
+                case ClientState.SendingConnectionRequest:
+                    {
+                        state = "sendingConnectionRequest";
+                        break;
+                    }
+                case ClientState.SendingConnectionResponse:
+                    {
+                        state = "sendingConnectionResponse";
+                        break;
+                    }
+                default:
+                    {
+                        state = "unknown";
+                        break;
+                    }
+            }
 
-			WriteMessage(new JArray
-			{
-				JValue.FromObject(TypeClientStateChanged),
-				JValue.FromObject(id),
-				JValue.FromObject(state),
-			});
-		}
+            WriteMessage(new JArray
+            {
+                JValue.FromObject(TypeClientStateChanged),
+                JValue.FromObject(id),
+                JValue.FromObject(state),
+            });
+        }
     }
 }

--- a/netcode.io.host/Program.cs
+++ b/netcode.io.host/Program.cs
@@ -42,6 +42,7 @@ namespace netcode.io.host
         const int TypeDestroyClient = 107;
         const int TypeClientDestroyed = 108;
         const int TypeCheckPresence = 109;
+		const int TypeClientStateChanged = 110;
 
         const int ResultClientCreated = 201;
         const int ResultSuccess = 202;
@@ -258,9 +259,18 @@ namespace netcode.io.host
             var id = (int)o;
             var managedClient = _clients[id];
 
+			// keep track of client state so we can notify application of state changes
+			var prevState = managedClient.client.State;
+			
             while (managedClient.shouldRun)
             {
                 managedClient.client.Update(managedClient.time);
+				
+				if (managedClient.client.State != prevState)
+				{
+					prevState = managedClient.client.State;
+					PostStateChange(id);
+				}
 
                 if (managedClient.client.State == ClientState.Connected)
                 {
@@ -302,5 +312,53 @@ namespace netcode.io.host
 
             managedClient.client.Dispose();
         }
+
+		private static void PostStateChange( int id )
+		{
+			string state;
+			switch (_clients[id].client.State)
+			{
+				case ClientState.Connected:
+					state = "connected";
+					break;
+				case ClientState.ConnectionDenied:
+					state = "connectionDenied";
+					break;
+				case ClientState.ConnectionRequestTimeout:
+					state = "connectionRequestTimeout";
+					break;
+				case ClientState.ConnectionResponseTimeout:
+					state = "connectionResponseTimeout";
+					break;
+				case ClientState.ConnectionTimedOut:
+					state = "connectionTimedOut";
+					break;
+				case ClientState.ConnectTokenExpired:
+					state = "connectTokenExpired";
+					break;
+				case ClientState.Disconnected:
+					state = "disconnected";
+					break;
+				case ClientState.InvalidConnectToken:
+					state = "invalidConnectToken";
+					break;
+				case ClientState.SendingConnectionRequest:
+					state = "sendingConnectionRequest";
+					break;
+				case ClientState.SendingConnectionResponse:
+					state = "sendingConnectionResponse";
+					break;
+				default:
+					state = "unknown";
+					break;
+			}
+
+			WriteMessage(new JArray
+			{
+				JValue.FromObject(TypeClientStateChanged),
+				JValue.FromObject(id),
+				JValue.FromObject(state),
+			});
+		}
     }
 }


### PR DESCRIPTION
This pull request would add support for subscribing to state changes by adding a new "stateChange" event type to the client.addEventListener function. As an example, this could be used to easily detect when a client has connected to a server without having to poll the client's state.